### PR TITLE
Fix: Balance sheet upload skipping Other Assets field

### DIFF
--- a/pages/data_input/excel_parser.py
+++ b/pages/data_input/excel_parser.py
@@ -502,7 +502,7 @@ def parse_sheet_with_description(uploaded_file, sheet_name: str, mapping: Dict, 
             category_headers = {
                 'revenue', 'direct expenses (cost of revenue)', 'operating expenses',
                 'other income/expenses', 'labor analysis', 'current assets', 'fixed assets',
-                'other assets', 'current liabilities', 'long-term liabilities', 'equity'
+                'current liabilities', 'long-term liabilities', 'equity'
             }
             if str(line_item).strip().lower() in category_headers:
                 continue


### PR DESCRIPTION
## Summary
- Remove 'other assets' from category_headers skip set in excel parser
- The field name collides with the section header name, causing uploaded Other Assets values to be silently dropped
- Section header rows without values are already filtered by the pd.isna() check

🤖 Generated with [Claude Code](https://claude.com/claude-code)