### PR TITLE
Fix: W&C re-upload duplicates + draft preview for super admins

### DIFF
--- a/pages/company_pages/company_wins_challenges.py
+++ b/pages/company_pages/company_wins_challenges.py
@@ -914,10 +914,12 @@ def display_wins_challenges_sections(balance_data, income_data):
         selected_period_type = 'Mid Year'
 
     # Fetch wins, challenges, and action items from Airtable
+    # Super admins see drafts + published (preview before publish); company users see published only
     airtable = get_airtable_connection()
-    wins_data = airtable.get_wins(company_name, period_name)
-    challenges_data = airtable.get_challenges(company_name, period_name)
-    action_items_data = airtable.get_action_items(company_name, period_name)
+    admin_view = is_super_admin()
+    wins_data = airtable.get_wins(company_name, period_name, include_drafts=admin_view)
+    challenges_data = airtable.get_challenges(company_name, period_name, include_drafts=admin_view)
+    action_items_data = airtable.get_action_items(company_name, period_name, include_drafts=admin_view)
 
     # Extract text from data (get_wins returns list of dicts with 'win_text' field)
     wins = [item['win_text'] for item in wins_data] if wins_data else []

--- a/pages/data_input/wc_uploader.py
+++ b/pages/data_input/wc_uploader.py
@@ -64,8 +64,8 @@ def upload_wc_to_airtable(
         if not period_id:
             return False, f"Period '{period_name}' not found for company '{company_name}'", counts
 
-        # Step 1: Delete existing drafts (overwrite behavior)
-        deleted = _delete_existing_drafts(manager, period_id)
+        # Step 1: Delete all existing records for this period (overwrite behavior)
+        deleted = _delete_existing_records(manager, period_id)
 
         # Step 2: Create new records as drafts
         errors = []
@@ -132,10 +132,11 @@ def upload_wc_to_airtable(
         return False, f"Upload failed: {str(e)}", counts
 
 
-def _delete_existing_drafts(manager: WinsChallengesActionItemsManager, period_id: str) -> Dict[str, int]:
+def _delete_existing_records(manager: WinsChallengesActionItemsManager, period_id: str) -> Dict[str, int]:
     """
-    Hard delete all draft records for a period (to allow overwrite).
-    Only deletes drafts, not published records.
+    Hard delete all active records for a period (both draft and published) to allow clean overwrite.
+    Fetches all active records and filters by period_id in Python — avoids unreliable ARRAYJOIN
+    on linked record fields.
 
     Args:
         manager: WinsChallengesActionItemsManager instance
@@ -154,17 +155,21 @@ def _delete_existing_drafts(manager: WinsChallengesActionItemsManager, period_id
 
     for table_name, count_key in tables:
         try:
-            # Fetch all draft records for this period
+            # Fetch all active records, then filter by period_id in Python
+            # (ARRAYJOIN on linked fields is unreliable — same pattern as airtable_connection.py)
             url = f"{manager.base_url}/{table_name}"
-            safe_period_id = _escape_airtable_value(period_id)
-            filter_formula = f"AND(FIND('{safe_period_id}', ARRAYJOIN({{period}})), {{status}}='draft', {{is_active}}=TRUE())"
-            params = {'filterByFormula': filter_formula}
+            params = {'filterByFormula': '{is_active}=TRUE()'}
 
             response = requests.get(url, headers=manager.headers, params=params)
             if response.status_code != 200:
                 continue
 
-            records = response.json().get('records', [])
+            all_records = response.json().get('records', [])
+            # Filter to only records linked to this period
+            records = [
+                r for r in all_records
+                if period_id in r.get('fields', {}).get('period', [])
+            ]
             if not records:
                 continue
 
@@ -172,16 +177,13 @@ def _delete_existing_drafts(manager: WinsChallengesActionItemsManager, period_id
             record_ids = [r['id'] for r in records]
             for i in range(0, len(record_ids), 10):
                 batch_ids = record_ids[i:i+10]
-                delete_url = f"{manager.base_url}/{table_name}"
-
-                # Airtable DELETE requires records[] query params
-                params = {'records[]': batch_ids}
-                delete_response = requests.delete(delete_url, headers=manager.headers, params=params)
+                delete_params = {'records[]': batch_ids}
+                delete_response = requests.delete(url, headers=manager.headers, params=delete_params)
 
                 if delete_response.status_code == 200:
                     deleted[count_key] += len(batch_ids)
 
-        except Exception as e:
+        except Exception:
             # Log but continue - don't fail the whole upload
             pass
 


### PR DESCRIPTION
## Summary
Porting the same two fixes applied to BPC2 (PR #16) to BPC1 — identical bugs were present in both codebases.

- Re-uploading W&C data stacked duplicates because the delete step only targeted `status='draft'` records, silently skipping published ones
- Super admins had no way to preview uploaded drafts on the dashboard before publishing

## Changes
- **`wc_uploader.py`**: Replaced unreliable `ARRAYJOIN` Airtable filter with Python-side period filtering. Renamed `_delete_existing_drafts` → `_delete_existing_records` and removed the `status='draft'` restriction so re-upload wipes both draft and published records for a clean slate
- **`company_wins_challenges.py`**: Super admins now see draft + published records (`include_drafts=True`); company users still see published only

## Test plan
- [ ] Upload W&C for a company, publish, then re-upload — verify no duplicates appear
- [ ] As super admin, upload W&C draft — verify it appears on the dashboard before publishing
- [ ] As company user, verify drafts are NOT visible until published

🤖 Generated with [Claude Code](https://claude.com/claude-code)