### PR TITLE
Port W&C Standard column and paragraph spacing fix from BPC2

### DIFF
--- a/pages/company_pages/company_wins_challenges.py
+++ b/pages/company_pages/company_wins_challenges.py
@@ -450,9 +450,21 @@ def create_multi_year_table(multi_year_data):
                     <th class="metric-header">Metric</th>
     '''
 
+    # IMAI competition standards for each metric (from Ratios sheet)
+    standards = {
+        'Gross Profit':      '25–45%',
+        'Operating Profit':  '8%',
+        'Net Profit':        '6%',
+        'Total Cost of Revenue': '—',
+        'Operating Expenses':    '—',
+    }
+
     # Add year headers
     for year in years:
         table_html += f'<th>{year}</th>'
+
+    # Standard column header — dark blue background, golden font (matches Group Avg in company_ratios.py)
+    table_html += '<th style="background-color: #025a9a; color: #ffe082; border: 1px solid #ddd; padding: 12px 16px; text-align: center; font-weight: 600; font-size: 14px;">Standard</th>'
 
     table_html += '''
                 </tr>
@@ -470,6 +482,10 @@ def create_multi_year_table(multi_year_data):
             formatted_value = format_percentage(value)
 
             table_html += f'<td style="background-color: white; text-align: center; font-weight: 600;">{formatted_value}</td>'
+
+        # Standard cell — light blue tint to visually separate from year columns
+        standard_value = standards.get(metric, '—')
+        table_html += f'<td style="background-color: #e3f2fd; text-align: center; font-weight: 600; border: 1px solid #ddd;">{standard_value}</td>'
 
         table_html += '</tr>'
 
@@ -1076,8 +1092,9 @@ def display_wins_challenges_sections(balance_data, income_data):
             prev = lines[i - 1].strip()
             curr = line.strip()
             if not curr:
-                # Empty line → paragraph break
-                parts.append('<br><br>')
+                # Empty line → paragraph break with explicit margin so it renders
+                # visually distinct inside <li>, not just two squished line-feeds
+                parts.append('<span style="display:block;margin-top:0.75em"></span>')
             elif curr.startswith('-') and prev and not prev.startswith('-'):
                 # Transition from body/header text into sub-bullets → add half-line gap
                 parts.append('<br><span style="display:block;height:0.5em"></span>' + line)


### PR DESCRIPTION
## Summary
Two changes ported from BPC2 dashboard (PRs #19 and #20):

**1. Standard column in Historical Margin Analysis table**
- Adds a **Standard** column as the rightmost column
- Values: Gross Profit (25–45%), Operating Profit (8%), Net Profit (6%), others (—)
- Header: dark blue (`#025a9a`) + golden (`#ffe082`) text, matching Group Avg style
- Cells: light blue tint (`#e3f2fd`) to visually distinguish from year data

**2. Paragraph spacing fix in W&C text rendering**
- Blank lines between paragraphs in W&C text now render with real visual separation
- `<br><br>` → `<span style="display:block;margin-top:0.75em">` inside `<li>` elements

## Test plan
- [ ] Open any company's Wins & Challenges page
- [ ] Confirm Standard column appears in historical margin table with correct header styling and values
- [ ] Confirm W&C entries with multi-paragraph text show clear paragraph separation

🤖 Generated with [Claude Code](https://claude.com/claude-code)