### PR TITLE
Fix color threshold boundary gaps for Working Capital % and OPM

### DIFF
--- a/pages/group_pages/group_ratios.py
+++ b/pages/group_pages/group_ratios.py
@@ -323,11 +323,11 @@ def get_cell_color(value, metric_name):
     thresholds = {
         'current_ratio': {'great': 2.0, 'caution': [1.2, 2.0], 'improve': 1.3},
         'debt_to_equity': {'great': 1.4, 'caution': [1.5, 2.9], 'improve': 3.0, 'reverse': True},
-        'working_capital_pct': {'great': 0.30, 'caution': [0.15, 0.29], 'improve': 0.15},  # 30% = 0.30
+        'working_capital_pct': {'great': 0.30, 'caution': [0.15, 0.2999], 'improve': 0.15},  # 30% = 0.30
         'survival_score': {'great': 3.0, 'caution': [2.0, 3.0], 'improve': 2.0},
         'sales_assets': {'great': 3.7, 'caution': [2.0, 3.6], 'improve': 2.0},
         'gpm': {'great': 0.25, 'caution': [0.20, 0.25], 'improve': 0.20},
-        'opm': {'great': 0.055, 'caution': [0.03, 0.054], 'improve': 0.03},
+        'opm': {'great': 0.055, 'caution': [0.03, 0.0549], 'improve': 0.03},
         'rev_per_employee': {'great': 550, 'caution': [325, 550], 'improve': 325},
         'ebitda_margin': {'great': 0.05, 'caution': [0.025, 0.05], 'improve': 0.025},
         'dso': {'great': 30, 'caution': [30, 60], 'improve': 60, 'reverse': True},
@@ -343,6 +343,11 @@ def get_cell_color(value, metric_name):
 
     try:
         val = float(value)
+
+        # Normalize percentage metrics that may be stored as full percent (e.g. 8.1 instead of 0.081)
+        pct_metrics = {'working_capital_pct', 'gpm', 'opm', 'npm', 'ebitda_margin', 'ocf_rev', 'fcf_rev', 'ncf_rev'}
+        if metric_name in pct_metrics and val > 1:
+            val = val / 100
 
         if is_reverse:
             # Lower is better

--- a/shared/excel_formatter.py
+++ b/shared/excel_formatter.py
@@ -47,11 +47,11 @@ THIN_BORDER = Border(
 RATIO_THRESHOLDS = {
     'Current Ratio': {'great': 2.0, 'caution': [1.2, 2.0], 'reverse': False},
     'Debt to Equity': {'great': 1.4, 'caution': [1.5, 2.9], 'reverse': True},
-    'Working Capital %': {'great': 0.30, 'caution': [0.15, 0.29], 'reverse': False},
+    'Working Capital %': {'great': 0.30, 'caution': [0.15, 0.2999], 'reverse': False},
     'Survival Score': {'great': 3.0, 'caution': [2.0, 3.0], 'reverse': False},
     'Sales/Assets': {'great': 3.7, 'caution': [2.0, 3.6], 'reverse': False},
     'Gross Profit Margin': {'great': 0.25, 'caution': [0.20, 0.25], 'reverse': False},
-    'Operating Profit Margin': {'great': 0.055, 'caution': [0.03, 0.054], 'reverse': False},
+    'Operating Profit Margin': {'great': 0.055, 'caution': [0.03, 0.0549], 'reverse': False},
     'Net Profit Margin': {'great': 0.05, 'caution': [0.03, 0.0499], 'reverse': False},
     'Revenue Per Employee': {'great': 550, 'caution': [325, 550], 'reverse': False},
     'EBITDA/Revenue': {'great': 0.05, 'caution': [0.025, 0.05], 'reverse': False},


### PR DESCRIPTION
## Summary
- Working Capital %: caution upper bound `0.29` → `0.2999` — values like 29.2% (0.292) were falling between yellow ceiling and green floor, showing red incorrectly
- OPM: caution upper bound `0.054` → `0.0549` — same gap at 5.41–5.49%
- Added normalization in `get_cell_color` for percentage metrics stored as full values (e.g. `8.1` instead of `0.081`) to prevent them from comparing against decimal thresholds
- Same boundary fixes applied to `excel_formatter.py` RATIO_THRESHOLDS

## Test plan
- [ ] Verify iWest 29.2% Working Capital shows yellow (was red)
- [ ] Verify AMJ 8.1% Working Capital shows red (was green)
- [ ] Verify OPM values between 5.41%–5.49% show yellow, not red
- [ ] Verify Excel export colors match web table for Working Capital and OPM rows
- [ ] Verify group_income_statement.py OPM color coding also fixed (imports get_cell_color from group_ratios)

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)